### PR TITLE
WIP: sequel 4, ruby 2.4: removed deprecations

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,27 @@
+engines:
+  rubocop:
+    enabled: true
+   bundler-audit:
+    enabled: true
+  brakeman:
+   	enabled: true
+  eslint:
+    enabled: false
+  csslint:
+    enabled: false
+  duplication:
+  	enabled: true
+    config:
+    	languages:
+      - ruby
+      	#mass_threshold: 30
+      - javascript
+ratings:
+  paths:
+  - lib/**
+  - examples/**
+exclude_paths:
+- spec/**/*
+- "**/vendor/**/*"
+- .bundle/
+- tmp/

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,27 +1,26 @@
 engines:
   rubocop:
     enabled: true
-   bundler-audit:
+  bundler-audit:
     enabled: true
   brakeman:
-   	enabled: true
+    enabled: true
   eslint:
     enabled: false
   csslint:
     enabled: false
   duplication:
-  	enabled: true
+    enabled: true
     config:
-    	languages:
+      languages:
       - ruby
-      	#mass_threshold: 30
       - javascript
 ratings:
   paths:
-  - lib/**
-  - examples/**
+  - "lib/**"
+  - "examples/**"
 exclude_paths:
-- spec/**/*
-- "**/vendor/**/*"
-- .bundle/
-- tmp/
+  - "spec/**/*"
+  - "**/vendor/**/*"
+  - ".bundle/"
+  - "tmp/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 addons:
-    postgresql: "9.3"
+  postgresql: "9.3"
 language: ruby
 rvm:
   - 2.0.0-p247
   - 2.1.2
+  - 2.3.3
+  - 2.4.1
 before_script: "bundle exec rake sequel:db:create"
 script: "bundle exec rspec"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 addons:
+  postgresql: "9.3"
   code_climate:
     repo_token:
       secure: De89PCKdDhG2WpuS40ZyCZgY/fd+H9muE+/1tGV0WUHD/evrxSNVYzImJTa1ygJInZeEz7lhAdpNXm1LkffEiLgdhoweqzaU14yvJ9Rig/MKMd+paRK8LQzavTMi4C4lNq+W667fZNMw1AJqtxPILCehPJDjkpve+Qfkeo1HMSY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ language: ruby
 rvm:
   - 2.0.0-p247
   - 2.1.2
+  - 2.2.5
   - 2.3.3
   - 2.4.1
-before_script: "bundle exec rake sequel:db:create"
+before_script: bundle exec rake sequel:db:create
 script: "bundle exec rspec"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 addons:
-  postgresql: "9.3"
+  postgresql: '9.3'
   code_climate:
     repo_token:
-      secure: De89PCKdDhG2WpuS40ZyCZgY/fd+H9muE+/1tGV0WUHD/evrxSNVYzImJTa1ygJInZeEz7lhAdpNXm1LkffEiLgdhoweqzaU14yvJ9Rig/MKMd+paRK8LQzavTMi4C4lNq+W667fZNMw1AJqtxPILCehPJDjkpve+Qfkeo1HMSY=
+      secure: YEh2fV5IEqmR5jmC7mB9ILhQ90qOYKQ9i4pX9NzmWB4DfEo2VJjiiC3D6TJPNb3mqBLgbOyfrvAJ4RrJmWpK0PEDcZv+U9OZ0dEVvWPQ6yy2qBtF/PssIuw3pkgyKxzQpteybAXd3rbwK6Bel66ndCGLmF4gwCKCLuNNRuu38Eo=
 language: ruby
 rvm:
 - 2.0.0-p648

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 addons:
-  postgresql: "9.3"
+  code_climate:
+    repo_token:
+      secure: De89PCKdDhG2WpuS40ZyCZgY/fd+H9muE+/1tGV0WUHD/evrxSNVYzImJTa1ygJInZeEz7lhAdpNXm1LkffEiLgdhoweqzaU14yvJ9Rig/MKMd+paRK8LQzavTMi4C4lNq+W667fZNMw1AJqtxPILCehPJDjkpve+Qfkeo1HMSY=
 language: ruby
 rvm:
-  - 2.0.0-p247
-  - 2.1.2
-  - 2.2.5
-  - 2.3.3
-  - 2.4.1
+- 2.0.0-p648
+- 2.1.10
+- 2.2.7
+- 2.3.4
+- 2.4.1
 before_script: bundle exec rake sequel:db:create
-script: "bundle exec rspec"
+script: bundle exec rspec
+after_success:
+- bundle exec codeclimate-test-reporter
 notifications:
   email: false

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,0 @@
-Contributors
-============
-
-* James Hart (james@wanelo.com)
-* Paul Henry (paul@wanelo.com)
-* Eric Saxby (sax@wanelo.com)

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem 'codeclimate-test-reporter'
+  gem 'simplecov'
   gem 'rspec'
   gem 'mocha', require: false
   gem 'pry-nav'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'codeclimate-test-reporter'
   gem 'simplecov'
   gem 'rspec'
   gem 'mocha', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 group :test do
   gem 'simplecov'
   gem 'rspec'
+  gem 'rspec-benchmark'
   gem 'mocha', require: false
   gem 'pry-nav'
 end

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ sequel-schema-sharding
 ======================
 
 [![Gem Version](https://badge.fury.io/rb/sequel-schema-sharding.svg)](https://badge.fury.io/rb/sequel-schema-sharding)
-[![Build Status](https://travis-ci.org/wanelo/sequel-schema-sharding.png?branch=master)](https://travis-ci.org/wanelo/sequel-schema-sharding)
+[![Build Status](https://travis-ci.org/wanelo/sequel-schema-sharding.svg?branch=ruby-2.4.sequel-4)](https://travis-ci.org/wanelo/sequel-schema-sharding)
 [![Code Climate](https://codeclimate.com/github/wanelo/sequel-schema-sharding/badges/gpa.svg)](https://codeclimate.com/github/wanelo/sequel-schema-sharding)
 [![Test Coverage](https://codeclimate.com/github/wanelo/sequel-schema-sharding/badges/coverage.svg)](https://codeclimate.com/github/wanelo/sequel-schema-sharding/coverage)
 

--- a/README.md
+++ b/README.md
@@ -359,3 +359,11 @@ may have been transposed between queries.
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+Contributors
+============
+
+* [James Hart](https://github.com/hjhart)
+* [Paul Henry](https://github.com/f3nry)
+* [Eric Saxby](https://github.com/sax)
+* [Konstatin Gredeskoul](https://github.com/kigster)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 sequel-schema-sharding
 ======================
 
-[![Gem Version](https://badge.fury.io/rb/sequel-schema-sharding.png)](http://badge.fury.io/rb/sequel-schema-sharding)
+[![Gem Version](https://badge.fury.io/rb/sequel-schema-sharding.svg)](https://badge.fury.io/rb/sequel-schema-sharding)
 [![Build Status](https://travis-ci.org/wanelo/sequel-schema-sharding.png?branch=master)](https://travis-ci.org/wanelo/sequel-schema-sharding)
-[![Code Climate](https://codeclimate.com/github/wanelo/sequel-schema-sharding.png)](https://codeclimate.com/github/wanelo/sequel-schema-sharding)
+[![Code Climate](https://codeclimate.com/github/wanelo/sequel-schema-sharding/badges/gpa.svg)](https://codeclimate.com/github/wanelo/sequel-schema-sharding)
+[![Test Coverage](https://codeclimate.com/github/wanelo/sequel-schema-sharding/badges/coverage.svg)](https://codeclimate.com/github/wanelo/sequel-schema-sharding/coverage)
 
 Horizontally shard PostgreSQL tables with the Sequel gem, where each shard
 lives in its own PostgreSQL schema.

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,10 @@
 require "bundler/gem_tasks"
 import 'lib/sequel/tasks/test.rake'
 import 'lib/sequel/tasks/reset.rake'
+
+task :default do 
+  system %Q{bundle exec rspec --exclude-pattern="spec/**/*database_manager_spec.rb"}
+end
+  
+
+

--- a/lib/sequel/schema-sharding.rb
+++ b/lib/sequel/schema-sharding.rb
@@ -6,11 +6,13 @@ require 'sequel/schema-sharding/configuration'
 require 'sequel/schema-sharding/connection_manager'
 require 'sequel/schema-sharding/database_manager'
 require 'sequel/schema-sharding/ring'
-require 'sequel/schema-sharding/finder'
+require 'sequel/schema-sharding/shard_finder'
 require 'sequel/schema-sharding/monkey_patching'
 require 'sequel/schema-sharding/model'
 require 'sequel/schema-sharding/logger_proxy'
 require 'sequel/schema-sharding/connection_strategies/random'
+
+Sequel.split_symbols = true if defined?(Sequel) && Sequel.respond_to?(:split_symbols=)
 
 module Sequel
   module SchemaSharding

--- a/lib/sequel/schema-sharding/shard_finder.rb
+++ b/lib/sequel/schema-sharding/shard_finder.rb
@@ -2,7 +2,7 @@ require 'singleton'
 
 module Sequel
   module SchemaSharding
-    class Finder
+    class ShardFinder
       class Result
         attr_reader :connection, :schema, :shard_number
 

--- a/lib/sequel/schema-sharding/version.rb
+++ b/lib/sequel/schema-sharding/version.rb
@@ -1,5 +1,5 @@
 module Sequel
   module SchemaSharding
-    VERSION = "0.13.4"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/sequel/schema-sharding/version.rb
+++ b/lib/sequel/schema-sharding/version.rb
@@ -1,5 +1,5 @@
 module Sequel
   module SchemaSharding
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end

--- a/lib/sequel/schema-sharding/version.rb
+++ b/lib/sequel/schema-sharding/version.rb
@@ -1,5 +1,5 @@
 module Sequel
   module SchemaSharding
-    VERSION = "1.0.0"
+    VERSION = '1.0.1'
   end
 end

--- a/sequel-schema-sharding.gemspec
+++ b/sequel-schema-sharding.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sequel-replica-failover', '~> 2'
   spec.add_dependency 'ruby-usdt', '>= 0.2.2'
 
+  spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
 end

--- a/sequel-schema-sharding.gemspec
+++ b/sequel-schema-sharding.gemspec
@@ -6,8 +6,8 @@ require 'sequel/schema-sharding/version'
 Gem::Specification.new do |spec|
   spec.name          = 'sequel-schema-sharding'
   spec.version       = Sequel::SchemaSharding::VERSION
-  spec.authors       = ['Paul Henry', 'James Hart', 'Eric Saxby']
-  spec.email         = %w(dev@wanelo.com)
+  spec.authors       = ['Paul Henry', 'James Hart', 'Eric Saxby', 'Konstantin Gredeskoul']
+  spec.email         = %w(dev@wanelo.com kigster@gmail.com)
   spec.description   = %q{}
   spec.summary       = %q{Create horizontally sharded Sequel models with Postgres}
   spec.homepage      = 'https://github.com/wanelo/sequel-schema-sharding'
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w(lib)
 
-  spec.add_dependency 'sequel'
+  spec.add_dependency 'sequel', '~> 4'
   spec.add_dependency 'pg'
-  spec.add_dependency 'sequel-replica-failover', '>= 2.0.0'
+  spec.add_dependency 'sequel-replica-failover', '~> 2'
   spec.add_dependency 'ruby-usdt', '>= 0.2.2'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
 end

--- a/spec/fixtures/db/migrate/artists/001_create_artists_table.rb
+++ b/spec/fixtures/db/migrate/artists/001_create_artists_table.rb
@@ -1,8 +1,7 @@
 Sequel.migration do
   up do
     create_table(migration_schema_for_table(:artists)) do
-      primary_key :id
-      Integer :artist_id
+      Integer :artist_id, unique: true
       String :name, :null=>false
     end
   end

--- a/spec/schema-sharding/connection_manager_spec.rb
+++ b/spec/schema-sharding/connection_manager_spec.rb
@@ -15,7 +15,7 @@ describe Sequel::SchemaSharding::ConnectionManager do
   describe '#[]' do
     it 'returns a valid connection instance for the specified physical shard' do
       expect(subject['shard1']).to be_a(Sequel::Postgres::Database)
-      subject['shard1'].execute("SELECT 1")
+      subject['shard1'].execute('SELECT 1')
       expect(subject['shard2']).to be_a(Sequel::Postgres::Database)
     end
 
@@ -45,7 +45,7 @@ describe Sequel::SchemaSharding::ConnectionManager do
 
       it 'executes a select against a replica' do
         shard = subject['shard2']
-        ds = shard[:"sequel_explosions_boof_pickles_3__artists"]
+        ds = shard[:'sequel_explosions_boof_pickles_3__artists']
         shard.expects(:execute).once.with(anything, server: :read_only)
         ds.first
       end
@@ -58,8 +58,8 @@ describe Sequel::SchemaSharding::ConnectionManager do
     end
   end
 
-  describe "#default_dataset_for" do
-    it "returns a dataset scoped to a configured schema" do
+  describe '#default_dataset_for' do
+    it 'returns a dataset scoped to a configured schema' do
       # TODO ConnectionManager is dependent on global state from Sequel::SchemaSharding.config.
       #      This should be deconstructed to allow for injection of a mock config for testing.
       dataset = subject.default_dataset_for("artists")

--- a/spec/schema-sharding/model_spec.rb
+++ b/spec/schema-sharding/model_spec.rb
@@ -2,96 +2,87 @@ require 'spec_helper'
 
 describe Sequel::SchemaSharding, 'Model' do
 
-  let(:model) do
-    klass = Sequel::SchemaSharding::Model('artists')
-    klass.instance_eval do
-      set_sharded_column :artist_id
-      set_columns [:artist_id, :name]
-
-      def by_id(id)
-        shard_for(id).where(artist_id: id)
-      end
-
-      def self.implicit_table_name
-        'artists'
-      end
-    end
-
-    klass.class_eval do
-      def this
-        @this ||= model.by_id(artist_id).limit(1)
-      end
-    end
-    klass
+  before do
+    require 'support/artist'
   end
 
-  describe 'reading from database' do
-    it 'can return a valid record' do
-      artist = model.create(artist_id: 14, name: 'Paul')
-      expect(artist.id).to_not be_nil
-      read_back_artist = model.by_id(14).first
-      expect(read_back_artist).to be_a(model)
-      expect(read_back_artist.name).to eql('Paul')
-      read_back_artist.destroy
-      read_back_artist = model.by_id(14).first
-      expect(read_back_artist).to be_nil
+  describe 'creating records and reading them from database' do
+    let(:artist_id) { 14 }
+    let(:another_artist_id) { 15 }
+
+    before do
+      Artist.shard_for(artist_id).truncate
     end
 
-    it 'includes shard number on model instances' do
-      shard_number = model.shard_for(456).shard_number
+    let(:artist_name) { 'Paul' }
+    let(:artist_hash) { { artist_id: artist_id, name: artist_name } }
+    let(:read_back_artist) { Artist.by_id(artist_id).first }
+    let(:artist) { Artist.create(artist_hash) }
 
-      model.create(artist_id: 456, name: 'Randy')
-      record = model.by_id(456).first
-      expect(record.shard_number).to eq(shard_number)
-    end
-  end
-
-  describe 'writing to database' do
     it 'can create a valid record' do
-      artist = model.create(artist_id: 234, name: 'Paul')
-      expect(artist).to be_a(model)
-      expect(artist.name).to eql('Paul')
-      artist.destroy
+      expect(artist.artist_id).to eq(artist_id)
+      expect(artist.name).to eq(artist_name)
     end
 
-    it 'includes shard number on model instances' do
-      shard_number = model.shard_for(5432).shard_number
-      expect(model.create(artist_id: 5432, name: 'WOW').shard_number).to eq(shard_number)
+    context 'with an artist created' do
+      before do
+        expect(artist).to_not be_nil
+      end
+
+      it 'can read back created record' do
+        expect(read_back_artist).to be_a(Artist)
+        expect(read_back_artist.name).to eql('Paul')
+        read_back_artist.destroy
+        read_back_artist = Artist.where(artist_id: artist_id).first
+        expect(read_back_artist).to be_nil
+      end
+
+      it 'includes shard number on model instances' do
+        shard_number = Artist.shard_for(artist_id).shard_number
+        expect(read_back_artist.shard_number).to eq(shard_number)
+      end
+
+      it 'sets different shard number for another ID' do
+        shard_number = Artist.shard_for(artist_id).shard_number
+        another_shard_number = Artist.shard_for(another_artist_id).shard_number
+        expect(another_shard_number).not_to eq(shard_number)
+      end
     end
+
+    describe '#shard_for' do
+      let(:dataset) { Artist.shard_for(2356) }
+
+      it 'returns a dataset' do
+        expect(dataset).to be_a(Sequel::Dataset)
+      end
+
+      it 'connects to the shard for the given id' do
+        expect(dataset.db.opts[:database]).to eq('sequel_test_shard2')
+        expect(dataset.first_source).to eq(:sequel_logical_artists_17__artists)
+      end
+
+      it 'includes shard_number on dataset' do
+        expect(dataset.shard_number).to eq(17)
+      end
+    end
+
+    describe '#read_only_shard_for' do
+      let(:dataset) { Artist.read_only_shard_for(2356) }
+
+      it 'returns a dataset' do
+        expect(dataset).to be_a(Sequel::Dataset)
+      end
+
+      it 'connects to the shard for the given id' do
+        expect(dataset.db.opts[:database]).to eq('sequel_test_shard2')
+        expect(dataset.first_source).to eq(:sequel_logical_artists_17__artists)
+      end
+
+      it 'is read_only' do
+        expect(dataset.opts[:server]).to eq(:read_only)
+      end
+    end
+
   end
-
-  describe '#shard_for' do
-    let(:dataset) { model.shard_for(2356) }
-
-    it 'returns a dataset' do
-      expect(dataset).to be_a(Sequel::Dataset)
-    end
-
-    it 'connects to the shard for the given id' do
-      expect(dataset.db.opts[:database]).to eq('sequel_test_shard2')
-      expect(dataset.first_source).to eq(:sequel_logical_artists_17__artists)
-    end
-
-    it 'includes shard_number on dataset' do
-      expect(dataset.shard_number).to eq(17)
-    end
-  end
-
-  describe '#read_only_shard_for' do
-    let(:dataset) { model.read_only_shard_for(2356) }
-
-    it 'returns a dataset' do
-      expect(dataset).to be_a(Sequel::Dataset)
-    end
-
-    it 'connects to the shard for the given id' do
-      expect(dataset.db.opts[:database]).to eq('sequel_test_shard2')
-      expect(dataset.first_source).to eq(:sequel_logical_artists_17__artists)
-    end
-
-    it 'is read_only' do
-      expect(dataset.opts[:server]).to eq(:read_only)
-    end
-  end
-
 end
+

--- a/spec/schema-sharding/model_spec.rb
+++ b/spec/schema-sharding/model_spec.rb
@@ -16,12 +16,20 @@ describe Sequel::SchemaSharding, 'Model' do
 
     let(:artist_name) { 'Paul' }
     let(:artist_hash) { { artist_id: artist_id, name: artist_name } }
-    let(:read_back_artist) { Artist.by_id(artist_id).first }
+    let(:read_back_artist_proc) { -> { Artist.by_id(artist_id).first }  }
+    let(:read_back_artist) { read_back_artist_proc[] }
     let(:artist) { Artist.create(artist_hash) }
 
     it 'can create a valid record' do
       expect(artist.artist_id).to eq(artist_id)
       expect(artist.name).to eq(artist_name)
+    end
+
+    it 'can truncate shards to mass-delete data' do
+      expect(artist.artist_id).to eq(artist_id)
+      expect(read_back_artist_proc[]).to be_a_kind_of(Artist)
+      expect(Artist.truncate_shards(artist_id)).to eq(1)
+      expect(read_back_artist_proc[]).to be_nil
     end
 
     context 'with an artist created' do

--- a/spec/schema-sharding/shard_finder_spec.rb
+++ b/spec/schema-sharding/shard_finder_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 require 'sequel/schema-sharding'
 require 'benchmark'
 
-describe Sequel::SchemaSharding::Finder do
+describe Sequel::SchemaSharding::ShardFinder do
 
   describe '.lookup' do
     it 'returns an object with a valid connection and schema' do
-      result = Sequel::SchemaSharding::Finder.instance.lookup('boof', 60)
+      result = Sequel::SchemaSharding::ShardFinder.instance.lookup('boof', 60)
       expect(result.connection).to be_a(Sequel::Postgres::Database)
       expect(result.schema).to eq('sequel_logical_boof_01')
       expect(result.shard_number).to eq(1)
@@ -16,7 +16,7 @@ describe Sequel::SchemaSharding::Finder do
       TIMES = 150_000
       result = Benchmark.measure do
         TIMES.times do
-          Sequel::SchemaSharding::Finder.instance.lookup('boof', 60)
+          Sequel::SchemaSharding::ShardFinder.instance.lookup('boof', 60)
         end
       end
       puts "performed #{TIMES} finder lookups: #{result}"

--- a/spec/schema-sharding/shard_finder_spec.rb
+++ b/spec/schema-sharding/shard_finder_spec.rb
@@ -12,14 +12,13 @@ describe Sequel::SchemaSharding::ShardFinder do
       expect(result.shard_number).to eq(1)
     end
 
-    xit 'is fast' do
-      TIMES = 150_000
-      result = Benchmark.measure do
-        TIMES.times do
+    context 'performance' do
+      include RSpec::Benchmark::Matchers
+      it 'is fast' do
+        expect do
           Sequel::SchemaSharding::ShardFinder.instance.lookup('boof', 60)
-        end
+        end.to perform_at_least(100000, time: 0.3, warmup: 0.1)
       end
-      puts "performed #{TIMES} finder lookups: #{result}"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 ENV['RACK_ENV'] ||= 'test'
 
+require 'simplecov'
+SimpleCov.start
+
 require 'bundler/setup'
 Bundler.require 'test'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,31 +22,8 @@ RSpec.configure do |config|
 
   config.before :all do |ex|
     Sequel::SchemaSharding.logger = Logger.new(StringIO.new)
-    Sequel::SchemaSharding.sharding_yml_path = "spec/fixtures/test_db_config.yml"
-    Sequel::SchemaSharding.migration_path = "spec/fixtures/db/migrate"
-  end
-
-  config.around :each, type: :transactional do |ex|
-    #Sequel::SchemaSharding.config = Sequel::SchemaSharding::Configuration.new('boom', 'spec/fixtures/test_db_config.yml')
-
-    # Start transactions in each connection to the physical shards
-    connections = Sequel::SchemaSharding.config.physical_shard_configs.map do |shard_config|
-      Sequel::SchemaSharding.connection_manager[shard_config[0]]
-    end
-
-    start_transaction_proc = Proc.new do |connections|
-      if connections.length == 0
-        ex.run
-      else
-        connections[0].transaction do
-          connections.shift
-          start_transaction_proc.call(connections)
-          raise Sequel::Rollback
-        end
-      end
-    end
-
-    start_transaction_proc.call(connections)
+    Sequel::SchemaSharding.sharding_yml_path = 'spec/fixtures/test_db_config.yml'
+    Sequel::SchemaSharding.migration_path = 'spec/fixtures/db/migrate'
   end
 
 end

--- a/spec/support/artist.rb
+++ b/spec/support/artist.rb
@@ -1,0 +1,24 @@
+class Artist < Sequel::SchemaSharding::Model('artists')
+  set_sharded_column :artist_id
+  set_columns [:artist_id, :name]
+
+  def self.by_id(artist_id)
+    shard_for(artist_id).where(artist_id: artist_id)
+  end
+  #
+  # def self.implicit_table_name
+  #   'artists'
+  # end
+
+  def this
+    @this ||= self.class.shard_for(self.artist_id).where(artist_id: self.artist_id)
+  end
+
+  def to_s
+    "<#{self.class.name}#{self.class.object_id}:[shared_column=#{self.class.sharded_column}]{artist_id: #{artist_id}, name: #{name}}"
+  end
+
+  def inspect
+    to_s
+  end
+end

--- a/spec/support/artist.rb
+++ b/spec/support/artist.rb
@@ -5,10 +5,6 @@ class Artist < Sequel::SchemaSharding::Model('artists')
   def self.by_id(artist_id)
     shard_for(artist_id).where(artist_id: artist_id)
   end
-  #
-  # def self.implicit_table_name
-  #   'artists'
-  # end
 
   def this
     @this ||= self.class.shard_for(self.artist_id).where(artist_id: self.artist_id)


### PR DESCRIPTION
- replaced `model=` and `row_proc=` with the options to Dataset#clone
 - refactored classes to be better named
 - renamed spec migrations to make more sense
 - removed unnecessary primary key ID from the test table
- [ref #142359853]